### PR TITLE
Add prototypical network training

### DIFF
--- a/analysis_integration.py
+++ b/analysis_integration.py
@@ -52,6 +52,7 @@ from analysis import (
     plot_tsne_embeddings,
     transition_entropy,
 )
+from prototype_network import train_prototypical_network
 
 # Optional: For additional clustering methods
 # from sklearn.cluster import AgglomerativeClustering, DBSCAN
@@ -677,6 +678,8 @@ def main():
                         help="Disable LLM calls if you have no OpenAI key.")
     parser.add_argument("--multi_modal", action="store_true",
                         help="Perform multi-modal clustering at the criminal level using Type 1 & Type 2 data.")
+    parser.add_argument("--train_proto_net", action="store_true",
+                        help="Train a prototypical network on clustered event embeddings.")
     args = parser.parse_args()
 
     os.makedirs(args.output_dir, exist_ok=True)
@@ -752,6 +755,14 @@ def main():
     with open(clusters_json_path, "w", encoding="utf-8") as jf:
         json.dump(cluster_info, jf, indent=4, ensure_ascii=False, default=numpy_to_python_default)
     print(f"[INFO] Global cluster info saved to {clusters_json_path}")
+
+    if args.train_proto_net:
+        print("[INFO] Training prototypical network on event embeddings...")
+        _, prototypes, val_acc = train_prototypical_network(embeddings, labels)
+        proto_path = os.path.join(args.output_dir, "prototypes.npy")
+        np.save(proto_path, prototypes)
+        print(f"[INFO] Prototypical network validation accuracy: {val_acc:.3f}")
+        print(f"[INFO] Prototypes saved to {proto_path}")
 
     # -------------------------------
     # Reconstruct Per-Criminal Cluster Sequences

--- a/prototype_network.py
+++ b/prototype_network.py
@@ -1,0 +1,78 @@
+import numpy as np
+import torch
+from torch import nn
+
+
+def compute_prototypes(embeddings, labels):
+    """Compute mean prototype vectors for each label."""
+    if not isinstance(embeddings, torch.Tensor):
+        embeddings = torch.tensor(embeddings, dtype=torch.float32)
+    else:
+        embeddings = embeddings.float()
+    if not isinstance(labels, torch.Tensor):
+        labels = torch.tensor(labels, dtype=torch.long)
+    else:
+        labels = labels.long()
+    unique_labels = torch.unique(labels)
+    prototypes = []
+    for lbl in unique_labels:
+        mask = labels == lbl
+        prototypes.append(embeddings[mask].mean(dim=0))
+    return torch.stack(prototypes, dim=0)
+
+
+class PrototypicalNetwork(nn.Module):
+    """Simple feed-forward encoder used in a prototypical network."""
+
+    def __init__(self, input_dim, hidden_dim=128, rep_dim=64):
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, rep_dim),
+        )
+
+    def forward(self, x, prototypes):
+        x = self.encoder(x)
+        if not isinstance(prototypes, torch.Tensor):
+            prototypes = torch.tensor(prototypes, dtype=x.dtype, device=x.device)
+        dists = torch.cdist(x, prototypes)
+        return -dists
+
+
+def train_prototypical_network(embeddings, labels, epochs=20, lr=1e-3):
+    """Train a prototypical network with simple episodic sampling."""
+    embeddings = torch.tensor(np.array(embeddings), dtype=torch.float32)
+    labels = torch.tensor(labels, dtype=torch.long)
+    model = PrototypicalNetwork(embeddings.shape[1])
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    n = len(labels)
+    val_acc = 0.0
+
+    for _ in range(epochs):
+        perm = torch.randperm(n)
+        split = max(1, int(0.8 * n))
+        sup_idx = perm[:split]
+        qry_idx = perm[split:]
+        sup_emb, sup_labels = embeddings[sup_idx], labels[sup_idx]
+        qry_emb, qry_labels = embeddings[qry_idx], labels[qry_idx]
+
+        model.train()
+        sup_encoded = model.encoder(sup_emb)
+        prototypes = compute_prototypes(sup_encoded, sup_labels)
+        qry_encoded = model.encoder(qry_emb)
+        dists = torch.cdist(qry_encoded, prototypes)
+        log_p_y = torch.log_softmax(-dists, dim=1)
+        loss = nn.functional.nll_loss(log_p_y, qry_labels)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+        with torch.no_grad():
+            preds = log_p_y.argmax(dim=1)
+            val_acc = (preds == qry_labels).float().mean().item()
+
+    with torch.no_grad():
+        all_encoded = model.encoder(embeddings)
+        final_prototypes = compute_prototypes(all_encoded, labels).cpu().numpy()
+    return model, final_prototypes, val_acc

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas
 scikit-learn
 seaborn
 sentence-transformers
+torch

--- a/tests/test_prototype_network.py
+++ b/tests/test_prototype_network.py
@@ -1,0 +1,11 @@
+import numpy as np
+from prototype_network import compute_prototypes
+
+
+def test_compute_prototypes_shape():
+    embeddings = np.array(
+        [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=np.float32
+    )
+    labels = np.array([0, 0, 1, 1])
+    protos = compute_prototypes(embeddings, labels)
+    assert protos.shape == (2, 2)


### PR DESCRIPTION
## Summary
- create `prototype_network.py` with prototypical network implementation
- add optional prototypical network training in `analysis_integration.py`
- add `torch` requirement
- test computing prototypes

## Testing
- `pip install torch` *(and other requirements)*
- `pip install nltk`
- `pip install openai`
- `pip install pandas`
- `pip install matplotlib`
- `pip install seaborn`
- `pip install sentence-transformers`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560672e6708320bc2e7d3e0870c31a